### PR TITLE
Increased the Varnish test timeout.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,7 +16,7 @@ nodist_libvmod_geoip2_la_SOURCES = \
 
 dist_man_MANS = vmod_geoip2.3
 
-VTC_LOG_COMPILER = $(VARNISHTEST) -v \
+VTC_LOG_COMPILER = $(VARNISHTEST) -v -t 120 \
 	-Dvmod_topbuild=$(abs_top_builddir) -Dvmod_topsrc=$(abs_top_srcdir)
 TEST_EXTENSIONS = .vtc
 TESTS = @VMOD_TESTS@


### PR DESCRIPTION
Test `b00002` completes in `60.4s` and is killed right before completion. I increased the varnishtest timeout to `120s` (default is `60s`)