### PR TITLE
ci: scope push trigger to devel/main to avoid duplicate PR builds

### DIFF
--- a/.github/workflows/ci-devel.yml
+++ b/.github/workflows/ci-devel.yml
@@ -2,14 +2,13 @@ name: ci-devel
 
 on:
   push:
+    branches: [devel, main]
   pull_request:
   schedule:
     - cron: "11 3 * * 6"
 
 jobs:
   test:
-    if: success() || failure()
-
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
`on: push` + `pull_request` fires both events when pushing to an open PR's
head branch, producing two runs. Restrict push to the integration
branches so PR-head pushes go through `pull_request` alone. 
Also remove the no-op `if: success() || failure()` (single job, nothing to guard).